### PR TITLE
rename arango envs

### DIFF
--- a/comps/chathistory/arango/README.md
+++ b/comps/chathistory/arango/README.md
@@ -9,13 +9,11 @@ This README provides setup guides and all the necessary information about the Ch
 See `config.py` for default values.
 
 ```bash
-export ARANGO_HOST=${ARANGO_HOST}
-export ARANGO_PORT=${ARANGO_PORT}
-export ARANGO_PROTOCOL=${ARANGO_PROTOCOL}
+export ARANGO_URL=${ARANGO_URL}
 export ARANGO_USERNAME=${ARANGO_USERNAME}
 export ARANGO_PASSWORD=${ARANGO_PASSWORD}
-export DB_NAME=${DB_NAME}
-export COLLECTION_NAME=${COLLECTION_NAME}
+export ARANGO_DB_NAME=${ARANGO_DB_NAME}
+export ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME}
 ```
 
 ---
@@ -44,13 +42,11 @@ docker build -t opea/chathistory-arango-server:latest --build-arg https_proxy=$h
   -e http_proxy=$http_proxy \
   -e https_proxy=$https_proxy \
   -e no_proxy=$no_proxy \
-  -e ARANGO_HOST=${ARANGO_HOST} \
-  -e ARANGO_PORT=${ARANGO_PORT} \
-  -e ARANGO_PROTOCOL=${ARANGO_PROTOCOL} \
+  -e ARANGO_URL=${ARANGO_URL} \
   -e ARANGO_USERNAME=${ARANGO_USERNAME} \
   -e ARANGO_PASSWORD=${ARANGO_PASSWORD} \
-  -e DB_NAME=${DB_NAME} \
-  -e COLLECTION_NAME=${COLLECTION_NAME} \
+  -e ARANGO_DB_NAME=${ARANGO_DB_NAME} \
+  -e ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME} \
   opea/chathistory-arango-server:latest
   ```
 

--- a/comps/chathistory/arango/arango_conn.py
+++ b/comps/chathistory/arango/arango_conn.py
@@ -3,11 +3,11 @@
 
 from arango import ArangoClient as PythonArangoClient
 from arango.database import StandardDatabase
-from config import ARANGO_HOST, ARANGO_PASSWORD, ARANGO_PORT, ARANGO_PROTOCOL, ARANGO_USERNAME, DB_NAME
+from config import ARANGO_URL, ARANGO_PASSWORD, ARANGO_USERNAME, ARANGO_DB_NAME
 
 
 class ArangoClient:
-    conn_url = f"{ARANGO_PROTOCOL}://{ARANGO_HOST}:{ARANGO_PORT}/"
+    conn_url = ARANGO_URL
 
     @staticmethod
     def get_db_client() -> StandardDatabase:
@@ -19,11 +19,11 @@ class ArangoClient:
             sys_db = client.db("_system", username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
 
             # Create target database if it doesn't exist
-            if not sys_db.has_database(DB_NAME):
-                sys_db.create_database(DB_NAME)
+            if not sys_db.has_database(ARANGO_DB_NAME):
+                sys_db.create_database(ARANGO_DB_NAME)
 
             # Now connect to the target database
-            db = client.db(DB_NAME, username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
+            db = client.db(ARANGO_DB_NAME, username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
 
             return db
 

--- a/comps/chathistory/arango/arango_store.py
+++ b/comps/chathistory/arango/arango_store.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from arango_conn import ArangoClient
-from config import COLLECTION_NAME
+from config import ARANGO_COLLECTION_NAME
 from pydantic import BaseModel
 
 
@@ -16,10 +16,10 @@ class DocumentStore:
     def initialize_storage(self) -> None:
         self.db_client = ArangoClient.get_db_client()
 
-        if not self.db_client.has_collection(COLLECTION_NAME):
-            self.db_client.create_collection(COLLECTION_NAME)
+        if not self.db_client.has_collection(ARANGO_COLLECTION_NAME):
+            self.db_client.create_collection(ARANGO_COLLECTION_NAME)
 
-        self.collection = self.db_client.collection(COLLECTION_NAME)
+        self.collection = self.db_client.collection(ARANGO_COLLECTION_NAME)
 
     def save_document(self, document: BaseModel) -> str:
         """Stores a new document into the storage.

--- a/comps/chathistory/arango/config.py
+++ b/comps/chathistory/arango/config.py
@@ -3,11 +3,9 @@
 
 import os
 
-# ARANGO configuration
-ARANGO_HOST = os.getenv("ARANGO_HOST", "localhost")
-ARANGO_PORT = os.getenv("ARANGO_PORT", 8529)
-ARANGO_PROTOCOL = os.getenv("ARANGO_PROTOCOL", "http")
+# ArangoDB configuration
+ARANGO_URL = os.getenv("ARANGO_URL", "http://localhost:8529")
 ARANGO_USERNAME = os.getenv("ARANGO_USERNAME", "root")
 ARANGO_PASSWORD = os.getenv("ARANGO_PASSWORD", "test")
-DB_NAME = os.getenv("DB_NAME", "OPEA")
-COLLECTION_NAME = os.getenv("COLLECTION_NAME", "ChatHistory")
+ARANGO_DB_NAME = os.getenv("ARANGO_DB_NAME", "OPEA")
+ARANGO_COLLECTION_NAME = os.getenv("ARANGO_COLLECTION_NAME", "ChatHistory")

--- a/comps/chathistory/arango/docker-compose-chathistory-arango.yaml
+++ b/comps/chathistory/arango/docker-compose-chathistory-arango.yaml
@@ -24,13 +24,11 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       no_proxy: ${no_proxy}
-      ARANGO_HOST: ${ARANGO_HOST}
-      ARANGO_PORT: ${ARANGO_PORT}
-      ARANGO_PROTOCOL: ${ARANGO_PROTOCOL}
+      ARANGO_URL: ${ARANGO_URL}
       ARANGO_USERNAME: ${ARANGO_USERNAME}
       ARANGO_PASSWORD: ${ARANGO_PASSWORD}
-      DB_NAME: ${DB_NAME}
-      COLLECTION_NAME: ${COLLECTION_NAME}
+      ARANGO_DB_NAME: ${ARANGO_DB_NAME}
+      ARANGO_COLLECTION_NAME: ${ARANGO_COLLECTION_NAME}
     restart: unless-stopped
 
 networks:

--- a/comps/feedback_management/arango/README.md
+++ b/comps/feedback_management/arango/README.md
@@ -9,13 +9,11 @@ This README provides setup guides and all the necessary information about the Fe
 See `config.py` for default values.
 
 ```bash
-export ARANGO_HOST=${ARANGO_HOST}
-export ARANGO_PORT=${ARANGO_PORT}
-export ARANGO_PROTOCOL=${ARANGO_PROTOCOL}
+export ARANGO_URL=${ARANGO_URL}
 export ARANGO_USERNAME=${ARANGO_USERNAME}
 export ARANGO_PASSWORD=${ARANGO_PASSWORD}
-export DB_NAME=${DB_NAME}
-export COLLECTION_NAME=${COLLECTION_NAME}
+export ARANGO_DB_NAME=${ARANGO_DB_NAME}
+export ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME}
 export PYTHONPATH={Path to base of directory}
 ```
 
@@ -46,13 +44,11 @@ docker build -t opea/feedbackmanagement-arango-server:latest --build-arg https_p
   -e http_proxy=$http_proxy \
   -e https_proxy=$https_proxy \
   -e no_proxy=$no_proxy \
-  -e ARANGO_HOST=${ARANGO_HOST} \
-  -e ARANGO_PORT=${ARANGO_PORT} \
-  -e ARANGO_PROTOCOL=${ARANGO_PROTOCOL} \
+  -e ARANGO_URL=${ARANGO_URL} \
   -e ARANGO_USERNAME=${ARANGO_USERNAME} \
   -e ARANGO_PASSWORD=${ARANGO_PASSWORD} \
-  -e DB_NAME=${DB_NAME} \
-  -e COLLECTION_NAME=${COLLECTION_NAME} \
+  -e ARANGO_DB_NAME=${ARANGO_DB_NAME} \
+  -e ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME} \
   opea/feedbackmanagement-arango-server:latest
 
   ```

--- a/comps/feedback_management/arango/arango_conn.py
+++ b/comps/feedback_management/arango/arango_conn.py
@@ -3,11 +3,11 @@
 
 from arango import ArangoClient as PythonArangoClient
 from arango.database import StandardDatabase
-from config import ARANGO_HOST, ARANGO_PASSWORD, ARANGO_PORT, ARANGO_PROTOCOL, ARANGO_USERNAME, DB_NAME
+from config import ARANGO_URL, ARANGO_PASSWORD, ARANGO_USERNAME, ARANGO_DB_NAME
 
 
 class ArangoClient:
-    conn_url = f"{ARANGO_PROTOCOL}://{ARANGO_HOST}:{ARANGO_PORT}/"
+    conn_url = ARANGO_URL
 
     @staticmethod
     def get_db_client() -> StandardDatabase:
@@ -19,11 +19,11 @@ class ArangoClient:
             sys_db = client.db("_system", username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
 
             # Create target database if it doesn't exist
-            if not sys_db.has_database(DB_NAME):
-                sys_db.create_database(DB_NAME)
+            if not sys_db.has_database(ARANGO_DB_NAME):
+                sys_db.create_database(ARANGO_DB_NAME)
 
             # Now connect to the target database
-            db = client.db(DB_NAME, username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
+            db = client.db(ARANGO_DB_NAME, username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
 
             return db
 

--- a/comps/feedback_management/arango/arango_store.py
+++ b/comps/feedback_management/arango/arango_store.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from arango_conn import ArangoClient
-from config import COLLECTION_NAME
+from config import ARANGO_COLLECTION_NAME
 from pydantic import BaseModel
 
 
@@ -17,10 +17,10 @@ class FeedbackStore:
     def initialize_storage(self) -> None:
         self.db_client = ArangoClient.get_db_client()
 
-        if not self.db_client.has_collection(COLLECTION_NAME):
-            self.db_client.create_collection(COLLECTION_NAME)
+        if not self.db_client.has_collection(ARANGO_COLLECTION_NAME):
+            self.db_client.create_collection(ARANGO_COLLECTION_NAME)
 
-        self.collection = self.db_client.collection(COLLECTION_NAME)
+        self.collection = self.db_client.collection(ARANGO_COLLECTION_NAME)
 
     def save_feedback(self, feedback_data: BaseModel) -> str:
         """Stores a new feedback data into the storage.

--- a/comps/feedback_management/arango/config.py
+++ b/comps/feedback_management/arango/config.py
@@ -3,7 +3,7 @@
 
 import os
 
-# ARANGO configuration
+# ArangoDB configuration
 ARANGO_URL = os.getenv("ARANGO_URL", "http://localhost:8529")
 ARANGO_USERNAME = os.getenv("ARANGO_USERNAME", "root")
 ARANGO_PASSWORD = os.getenv("ARANGO_PASSWORD", "test")

--- a/comps/feedback_management/arango/config.py
+++ b/comps/feedback_management/arango/config.py
@@ -4,10 +4,8 @@
 import os
 
 # ARANGO configuration
-ARANGO_HOST = os.getenv("ARANGO_HOST", "localhost")
-ARANGO_PORT = os.getenv("ARANGO_PORT", 8529)
-ARANGO_PROTOCOL = os.getenv("ARANGO_PROTOCOL", "http")
+ARANGO_URL = os.getenv("ARANGO_URL", "http://localhost:8529")
 ARANGO_USERNAME = os.getenv("ARANGO_USERNAME", "root")
 ARANGO_PASSWORD = os.getenv("ARANGO_PASSWORD", "test")
-DB_NAME = os.getenv("DB_NAME", "OPEA")
-COLLECTION_NAME = os.getenv("COLLECTION_NAME", "Feedback")
+ARANGO_DB_NAME = os.getenv("ARANGO_DB_NAME", "OPEA")
+ARANGO_COLLECTION_NAME = os.getenv("ARANGO_COLLECTION_NAME", "Feedback")

--- a/comps/feedback_management/arango/docker-compose-user-feedback-arango.yaml
+++ b/comps/feedback_management/arango/docker-compose-user-feedback-arango.yaml
@@ -24,13 +24,11 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       no_proxy: ${no_proxy}
-      ARANGO_HOST: ${ARANGO_HOST}
-      ARANGO_PORT: ${ARANGO_PORT}
-      ARANGO_PROTOCOL: ${ARANGO_PROTOCOL}
+      ARANGO_URL: ${ARANGO_URL}
       ARANGO_USERNAME: ${ARANGO_USERNAME}
       ARANGO_PASSWORD: ${ARANGO_PASSWORD}
-      DB_NAME: ${DB_NAME}
-      COLLECTION_NAME: ${COLLECTION_NAME}
+      ARANGO_DB_NAME: ${ARANGO_DB_NAME}
+      ARANGO_COLLECTION_NAME: ${ARANGO_COLLECTION_NAME}
     restart: unless-stopped
 
 networks:

--- a/comps/prompt_registry/arango/README.md
+++ b/comps/prompt_registry/arango/README.md
@@ -9,13 +9,11 @@ This README provides setup guides and all the necessary information about the Pr
 See `config.py` for default values.
 
 ```bash
-export ARANGO_HOST=${ARANGO_HOST}
-export ARANGO_PORT=${ARANGO_PORT}
-export ARANGO_PROTOCOL=${ARANGO_PROTOCOL}
+export ARANGO_URL=${ARANGO_URL}
 export ARANGO_USERNAME=${ARANGO_USERNAME}
 export ARANGO_PASSWORD=${ARANGO_PASSWORD}
-export DB_NAME=${DB_NAME}
-export COLLECTION_NAME=${COLLECTION_NAME}
+export ARANGO_DB_NAME=${ARANGO_DB_NAME}
+export ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME}
 ```
 
 ---
@@ -46,13 +44,11 @@ docker build -t opea/promptregistry-arango-server:latest --build-arg https_proxy
   -e http_proxy=$http_proxy \
   -e https_proxy=$https_proxy \
   -e no_proxy=$no_proxy \
-  -e ARANGO_HOST=${ARANGO_HOST} \
-  -e ARANGO_PORT=${ARANGO_PORT} \
-  -e ARANGO_PROTOCOL=${ARANGO_PROTOCOL} \
+  -e ARANGO_URL=${ARANGO_URL} \
   -e ARANGO_USERNAME=${ARANGO_USERNAME} \
   -e ARANGO_PASSWORD=${ARANGO_PASSWORD} \
-  -e DB_NAME=${DB_NAME} \
-  -e COLLECTION_NAME=${COLLECTION_NAME} \
+  -e ARANGO_DB_NAME=${ARANGO_DB_NAME} \
+  -e ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME} \
   opea/promptregistry-arango-server:latest
 
   ```

--- a/comps/prompt_registry/arango/arango_conn.py
+++ b/comps/prompt_registry/arango/arango_conn.py
@@ -3,11 +3,11 @@
 
 from arango import ArangoClient as PythonArangoClient
 from arango.database import StandardDatabase
-from config import ARANGO_HOST, ARANGO_PASSWORD, ARANGO_PORT, ARANGO_PROTOCOL, ARANGO_USERNAME, DB_NAME
+from config import ARANGO_URL, ARANGO_PASSWORD, ARANGO_USERNAME, ARANGO_DB_NAME
 
 
 class ArangoClient:
-    conn_url = f"{ARANGO_PROTOCOL}://{ARANGO_HOST}:{ARANGO_PORT}/"
+    conn_url = ARANGO_URL
 
     @staticmethod
     def get_db_client() -> StandardDatabase:
@@ -19,11 +19,11 @@ class ArangoClient:
             sys_db = client.db("_system", username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
 
             # Create target database if it doesn't exist
-            if not sys_db.has_database(DB_NAME):
-                sys_db.create_database(DB_NAME)
+            if not sys_db.has_database(ARANGO_DB_NAME):
+                sys_db.create_database(ARANGO_DB_NAME)
 
             # Now connect to the target database
-            db = client.db(DB_NAME, username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
+            db = client.db(ARANGO_DB_NAME, username=ARANGO_USERNAME, password=ARANGO_PASSWORD, verify=True)
 
             return db
 

--- a/comps/prompt_registry/arango/arango_store.py
+++ b/comps/prompt_registry/arango/arango_store.py
@@ -5,9 +5,8 @@ import os
 
 from arango.exceptions import IndexGetError
 from arango_conn import ArangoClient
-from config import COLLECTION_NAME
+from config import ARANGO_COLLECTION_NAME
 from prompt import PromptCreate
-from pydantic import BaseModel
 
 from comps import CustomLogger
 
@@ -27,10 +26,10 @@ class PromptStore:
     def initialize_storage(self) -> None:
         self.db_client = ArangoClient.get_db_client()
 
-        if not self.db_client.has_collection(COLLECTION_NAME):
-            self.db_client.create_collection(COLLECTION_NAME)
+        if not self.db_client.has_collection(ARANGO_COLLECTION_NAME):
+            self.db_client.create_collection(ARANGO_COLLECTION_NAME)
 
-        self.collection = self.db_client.collection(COLLECTION_NAME)
+        self.collection = self.db_client.collection(ARANGO_COLLECTION_NAME)
 
     def save_prompt(self, prompt: PromptCreate):
         """Stores a new prompt into the storage.

--- a/comps/prompt_registry/arango/config.py
+++ b/comps/prompt_registry/arango/config.py
@@ -3,7 +3,7 @@
 
 import os
 
-# ARANGO configuration
+# ArangoDB configuration
 ARANGO_URL = os.getenv("ARANGO_URL", "http://localhost:8529")
 ARANGO_USERNAME = os.getenv("ARANGO_USERNAME", "root")
 ARANGO_PASSWORD = os.getenv("ARANGO_PASSWORD", "test")

--- a/comps/prompt_registry/arango/config.py
+++ b/comps/prompt_registry/arango/config.py
@@ -4,10 +4,8 @@
 import os
 
 # ARANGO configuration
-ARANGO_HOST = os.getenv("ARANGO_HOST", "localhost")
-ARANGO_PORT = os.getenv("ARANGO_PORT", 8529)
-ARANGO_PROTOCOL = os.getenv("ARANGO_PROTOCOL", "http")
+ARANGO_URL = os.getenv("ARANGO_URL", "http://localhost:8529")
 ARANGO_USERNAME = os.getenv("ARANGO_USERNAME", "root")
 ARANGO_PASSWORD = os.getenv("ARANGO_PASSWORD", "test")
-DB_NAME = os.getenv("DB_NAME", "OPEA")
-COLLECTION_NAME = os.getenv("COLLECTION_NAME", "Prompt")
+ARANGO_DB_NAME = os.getenv("ARANGO_DB_NAME", "OPEA")
+ARANGO_COLLECTION_NAME = os.getenv("ARANGO_COLLECTION_NAME", "Prompt")

--- a/comps/prompt_registry/arango/docker-compose-prompt-registry-arango.yaml
+++ b/comps/prompt_registry/arango/docker-compose-prompt-registry-arango.yaml
@@ -24,13 +24,11 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       no_proxy: ${no_proxy}
-      ARANGO_HOST: ${ARANGO_HOST}
-      ARANGO_PORT: ${ARANGO_PORT}
-      ARANGO_PROTOCOL: ${ARANGO_PROTOCOL}
+      ARANGO_URL: ${ARANGO_URL}
       ARANGO_USERNAME: ${ARANGO_USERNAME}
       ARANGO_PASSWORD: ${ARANGO_PASSWORD}
-      DB_NAME: ${DB_NAME}
-      COLLECTION_NAME: ${COLLECTION_NAME}
+      ARANGO_DB_NAME: ${DB_NAME}
+      ARANGO_COLLECTION_NAME: ${COLLECTION_NAME}
     restart: unless-stopped
 
 networks:

--- a/tests/chathistory/test_chathistory_arango.sh
+++ b/tests/chathistory/test_chathistory_arango.sh
@@ -7,13 +7,11 @@ set -x
 WORKPATH=$(dirname "$PWD")
 ip_address=$(hostname -I | awk '{print $1}')
 
-export ARANGO_HOST=${ip_address}
-export ARANGO_PORT=8529
-export ARANGO_PROTOCOL=${ARANGO_PROTOCOL:-"http"}
+export ARANGO_URL=${ARANGO_URL:-"http://${ip_address}:8529"} 
 export ARANGO_USERNAME=${ARANGO_USERNAME:-"root"}
 export ARANGO_PASSWORD=${ARANGO_PASSWORD:-"test"}
-export DB_NAME=${DB_NAME:-"Conversations"}
-export COLLECTION_NAME=${COLLECTION_NAME:-"test"}
+export ARANGO_DB_NAME=${ARANGO_DB_NAME:-"Conversations"}
+export ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME:-"test"}
 
 function build_docker_images() {
     cd $WORKPATH
@@ -36,13 +34,11 @@ function start_service() {
         -e http_proxy=$http_proxy \
         -e https_proxy=$https_proxy \
         -e no_proxy=$no_proxy \
-        -e ARANGO_HOST=${ARANGO_HOST} \
-        -e ARANGO_PORT=${ARANGO_PORT} \
-        -e ARANGO_PROTOCOL=${ARANGO_PROTOCOL} \
+        -e ARANGO_URL=${ARANGO_URL} \
         -e ARANGO_USERNAME=${ARANGO_USERNAME} \
         -e ARANGO_PASSWORD=${ARANGO_PASSWORD} \
-        -e DB_NAME=${DB_NAME} \
-        -e COLLECTION_NAME=${COLLECTION_NAME} \
+        -e ARANGO_DB_NAME=${ARANGO_DB_NAME} \
+        -e ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME} \
         opea/chathistory-arango-server:comps
 
     sleep 10s

--- a/tests/feedback_management/test_feedback_management_arango.sh
+++ b/tests/feedback_management/test_feedback_management_arango.sh
@@ -7,13 +7,11 @@ set -xe
 WORKPATH=$(dirname "$PWD")
 ip_address=$(hostname -I | awk '{print $1}')
 
-export ARANGO_HOST=${ip_address}
-export ARANGO_PORT=8529
-export ARANGO_PROTOCOL=${ARANGO_PROTOCOL:-"http"}
+export ARANGO_URL=${ARANGO_URL:-"http://${ip_address}:8529"} 
 export ARANGO_USERNAME=${ARANGO_USERNAME:-"root"}
 export ARANGO_PASSWORD=${ARANGO_PASSWORD:-"test"}
-export DB_NAME=${DB_NAME:-"Feedback"}
-export COLLECTION_NAME=${COLLECTION_NAME:-"test"}
+export ARANGO_DB_NAME=${ARANGO_DB_NAME:-"Feedback"}
+export ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME:-"test"}
 
 function build_docker_images() {
     cd $WORKPATH
@@ -36,13 +34,11 @@ function start_service() {
         -e http_proxy=$http_proxy \
         -e https_proxy=$https_proxy \
         -e no_proxy=$no_proxy \
-        -e ARANGO_HOST=${ARANGO_HOST} \
-        -e ARANGO_PORT=${ARANGO_PORT} \
-        -e ARANGO_PROTOCOL=${ARANGO_PROTOCOL} \
+        -e ARANGO_URL=${ARANGO_URL} \
         -e ARANGO_USERNAME=${ARANGO_USERNAME} \
         -e ARANGO_PASSWORD=${ARANGO_PASSWORD} \
-        -e DB_NAME=${DB_NAME} \
-        -e COLLECTION_NAME=${COLLECTION_NAME} \
+        -e ARANGO_DB_NAME=${ARANGO_DB_NAME} \
+        -e ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME} \
         opea/feedbackmanagement-arango-server:comps
 
     sleep 10s

--- a/tests/prompt_registry/test_prompt_registry_arango.sh
+++ b/tests/prompt_registry/test_prompt_registry_arango.sh
@@ -7,13 +7,11 @@ set -x
 WORKPATH=$(dirname "$PWD")
 ip_address=$(hostname -I | awk '{print $1}')
 
-export ARANGO_HOST=${ip_address}
-export ARANGO_PORT=8529
-export ARANGO_PROTOCOL=${ARANGO_PROTOCOL:-"http"}
+export ARANGO_URL=${ARANGO_URL:-"http://${ip_address}:8529"} 
 export ARANGO_USERNAME=${ARANGO_USERNAME:-"root"}
 export ARANGO_PASSWORD=${ARANGO_PASSWORD:-"test"}
-export DB_NAME=${DB_NAME:-"Prompts"}
-export COLLECTION_NAME=${COLLECTION_NAME:-"test"}
+export ARANGO_DB_NAME=${ARANGO_DB_NAME:-"Prompts"}
+export ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME:-"test"}
 
 function build_docker_images() {
     cd $WORKPATH
@@ -36,13 +34,11 @@ function start_service() {
         -e http_proxy=$http_proxy \
         -e https_proxy=$https_proxy \
         -e no_proxy=$no_proxy \
-        -e ARANGO_HOST=${ARANGO_HOST} \
-        -e ARANGO_PORT=${ARANGO_PORT} \
-        -e ARANGO_PROTOCOL=${ARANGO_PROTOCOL} \
+        -e ARANGO_URL=${ARANGO_URL} \
         -e ARANGO_USERNAME=${ARANGO_USERNAME} \
         -e ARANGO_PASSWORD=${ARANGO_PASSWORD} \
-        -e DB_NAME=${DB_NAME} \
-        -e COLLECTION_NAME=${COLLECTION_NAME} \
+        -e ARANGO_DB_NAME=${ARANGO_DB_NAME} \
+        -e ARANGO_COLLECTION_NAME=${ARANGO_COLLECTION_NAME} \
         opea/promptregistry-arango-server:comps
 
     sleep 10s


### PR DESCRIPTION
Renaming some ArangoDB Environment Variables to establish a consistent naming pattern:

- `ARANGO_HOST`, `ARANGO_PROTOCOL`, `ARANGO_PORT` have been merged into `ARANGO_URL`
- `DB_NAME` is now `ARANGO_DB_NAME`
- `COLLECTION_NAME` is now `ARANGO_COLLECTION_NAME`

