### PR TITLE
dataprep improvements

### DIFF
--- a/comps/dataprep/arango/langchain/README.md
+++ b/comps/dataprep/arango/langchain/README.md
@@ -118,7 +118,8 @@ ArangoDB Connection configuration
 ArangoDB Graph Insertion configuration
 - `INSERT_ASYNC`: If set to True, the microservice will insert the data into ArangoDB asynchronously. Defaults to `False`.
 - `ARANGO_BATCH_SIZE`: The batch size for the microservice to insert the data. Defaults to `500`.
-- `ARANGO_GRAPH_NAME`: The name of the graph to use/create in ArangoDB. If this environment variable is not set, the microservice will use the file name as the graph name. Defaults to `GRAPH`. 
+- `ARANGO_GRAPH_NAME`: The name of the graph to use/create in ArangoDB Defaults to `GRAPH`. 
+- `ARANGO_USE_GRAPH_NAME`: If set to True, the microservice will use the graph name specified in the environment variable `ARANGO_GRAPH_NAME`. If set to False, the file name will be used as the graph name. Defaults to `True`.
 
 Text Generation Inference Configuration
 - `TGI_LLM_ENDPOINT`: The endpoint for the TGI service.

--- a/comps/dataprep/arango/langchain/README.md
+++ b/comps/dataprep/arango/langchain/README.md
@@ -116,9 +116,9 @@ ArangoDB Connection configuration
 - `ARANGO_DB_NAME`: The name of the database to use for the ArangoDB service.
 
 ArangoDB Graph Insertion configuration
-- `USE_ONE_ENTITY_COLLECTION`: If set to True, the microservice will use a single entity collection for all nodes. If set to False, the microservice will use a separate collection by node type. Defaults to `True`.
 - `INSERT_ASYNC`: If set to True, the microservice will insert the data into ArangoDB asynchronously. Defaults to `False`.
 - `ARANGO_BATCH_SIZE`: The batch size for the microservice to insert the data. Defaults to `500`.
+- `ARANGO_GRAPH_NAME`: The name of the graph to use/create in ArangoDB. Defaults to `GRAPH`. If this environment variable is not set, the microservice will use the file name as the graph name.
 
 Text Generation Inference Configuration
 - `TGI_LLM_ENDPOINT`: The endpoint for the TGI service.

--- a/comps/dataprep/arango/langchain/README.md
+++ b/comps/dataprep/arango/langchain/README.md
@@ -118,7 +118,7 @@ ArangoDB Connection configuration
 ArangoDB Graph Insertion configuration
 - `INSERT_ASYNC`: If set to True, the microservice will insert the data into ArangoDB asynchronously. Defaults to `False`.
 - `ARANGO_BATCH_SIZE`: The batch size for the microservice to insert the data. Defaults to `500`.
-- `ARANGO_GRAPH_NAME`: The name of the graph to use/create in ArangoDB. Defaults to `GRAPH`. If this environment variable is not set, the microservice will use the file name as the graph name.
+- `ARANGO_GRAPH_NAME`: The name of the graph to use/create in ArangoDB. If this environment variable is not set, the microservice will use the file name as the graph name. Defaults to `GRAPH`. 
 
 Text Generation Inference Configuration
 - `TGI_LLM_ENDPOINT`: The endpoint for the TGI service.

--- a/comps/dataprep/arango/langchain/config.py
+++ b/comps/dataprep/arango/langchain/config.py
@@ -13,6 +13,7 @@ ARANGO_DB_NAME = os.getenv("ARANGO_DB_NAME", "_system")
 INSERT_ASYNC = os.getenv("INSERT_ASYNC", False)
 ARANGO_BATCH_SIZE = os.getenv("ARANGO_BATCH_SIZE", 500)
 ARANGO_GRAPH_NAME = os.getenv("ARANGO_GRAPH_NAME", "GRAPH")
+ARANGO_USE_GRAPH_NAME = os.getenv("ARANGO_USE_GRAPH_NAME", True)
 
 # Text Generation Inference configuration
 TGI_LLM_ENDPOINT = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")

--- a/comps/dataprep/arango/langchain/config.py
+++ b/comps/dataprep/arango/langchain/config.py
@@ -29,10 +29,12 @@ TEI_EMBED_MODEL = os.getenv("TEI_EMBED_MODEL", "BAAI/bge-base-en-v1.5")
 
 # OpenAI configuration (alternative to TGI & TEI)
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-OPENAI_EMBED_MODEL = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
-OPENAI_EMBED_DIMENSIONS = os.getenv("OPENAI_EMBED_DIMENSIONS", 512)
 OPENAI_CHAT_MODEL = os.getenv("OPENAI_CHAT_MODEL", "gpt-4o")
 OPENAI_CHAT_TEMPERATURE = os.getenv("OPENAI_CHAT_TEMPERATURE", 0)
+OPENAI_EMBED_MODEL = os.getenv("OPENAI_EMBED_MODEL", "text-embedding-3-small")
+OPENAI_EMBED_DIMENSIONS = os.getenv("OPENAI_EMBED_DIMENSIONS", 512)
+OPENAI_CHAT_ENABLED = os.getenv("OPENAI_TEI_ENABLED", True)
+OPENAI_EMBED_ENABLED = os.getenv("OPENAI_TGI_ENABLED", True)
 
 # LLMGraphTransformer configuration
 SYSTEM_PROMPT_PATH = os.getenv("SYSTEM_PROMPT_PATH")

--- a/comps/dataprep/arango/langchain/config.py
+++ b/comps/dataprep/arango/langchain/config.py
@@ -10,9 +10,9 @@ ARANGO_PASSWORD = os.getenv("ARANGO_PASSWORD", "test")
 ARANGO_DB_NAME = os.getenv("ARANGO_DB_NAME", "_system")
 
 # ArangoDB Graph Insertion configuration
-USE_ONE_ENTITY_COLLECTION = os.getenv("USE_ONE_ENTITY_COLLECTION", True)
 INSERT_ASYNC = os.getenv("INSERT_ASYNC", False)
 ARANGO_BATCH_SIZE = os.getenv("ARANGO_BATCH_SIZE", 500)
+ARANGO_GRAPH_NAME = os.getenv("ARANGO_GRAPH_NAME", "GRAPH")
 
 # Text Generation Inference configuration
 TGI_LLM_ENDPOINT = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")

--- a/comps/dataprep/arango/langchain/docker-compose-dataprep-arango.yaml
+++ b/comps/dataprep/arango/langchain/docker-compose-dataprep-arango.yaml
@@ -10,6 +10,22 @@ services:
       - "8529:8529"
     environment:
       ARANGO_ROOT_PASSWORD: ${ARANGO_PASSWORD}
+  tei-embedding-service:
+    image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.5
+    container_name: tei-embedding-server
+    ports:
+      - "6006:80"
+    volumes:
+      - "./data:/data"
+    shm_size: 1g
+    environment:
+      no_proxy: ${no_proxy}
+      NO_PROXY: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      HUGGING_FACE_HUB_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+    ipc: host
+    command: --model-id ${EMBEDDING_MODEL_ID} --auto-truncate
   tgi_gaudi_service:
     image: ghcr.io/huggingface/tgi-gaudi:2.0.5
     container_name: tgi-service
@@ -30,6 +46,7 @@ services:
     depends_on:
       - arango-vector-db
       - tgi_gaudi_service
+      - tei-embedding-service
     ports:
       - "6007:6007"
     ipc: host

--- a/comps/dataprep/arango/langchain/prepare_doc_arango.py
+++ b/comps/dataprep/arango/langchain/prepare_doc_arango.py
@@ -34,6 +34,8 @@ from config import (
     TGI_LLM_TIMEOUT,
     TGI_LLM_TOP_K,
     TGI_LLM_TOP_P,
+    OPENAI_CHAT_ENABLED,
+    OPENAI_EMBED_ENABLED,
 )
 from fastapi import File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -145,15 +147,12 @@ def ingest_data_to_arango(doc_path: DocPath) -> str:
         file_name = os.path.basename(path).split(".")[0]
         graph_name = "".join(c for c in file_name if c.isalnum() or c in "_-:.@()+,=;$!*'%")
 
-    generate_chunk_embeddings = embeddings is not None
-
     for text in chunks:
         document = Document(page_content=text)
         graph_doc = llm_transformer.process_response(document)
 
-        if generate_chunk_embeddings:
-            source = graph_doc.source
-            source.metadata["embedding"] = embeddings.embed_documents([source.page_content])[0]
+        source = graph_doc.source
+        source.metadata["embedding"] = embeddings.embed_documents([source.page_content])[0]
 
         graph.add_graph_documents(
             graph_documents=[graph_doc],
@@ -267,7 +266,7 @@ if __name__ == "__main__":
     # Text Generation Inference #
     #############################
 
-    if OPENAI_API_KEY:
+    if OPENAI_API_KEY and OPENAI_CHAT_ENABLED:
         if logflag:
             logger.info("OpenAI API Key is set. Verifying its validity...")
         openai.api_key = OPENAI_API_KEY
@@ -294,7 +293,7 @@ if __name__ == "__main__":
             timeout=TGI_LLM_TIMEOUT,
         )
     else:
-        raise ValueError("No text generation inference endpoint is set.")
+        raise ValueError("No text generation environment variables are set, cannot generate graphs.")
 
     try:
         llm_transformer = LLMGraphTransformer(
@@ -320,7 +319,7 @@ if __name__ == "__main__":
     # Text Embeddings Inference (optional) #
     ########################################
 
-    if OPENAI_API_KEY:
+    if OPENAI_API_KEY and OPENAI_EMBED_ENABLED:
         # Use OpenAI embeddings
         embeddings = OpenAIEmbeddings(
             model=OPENAI_EMBED_MODEL,
@@ -337,9 +336,7 @@ if __name__ == "__main__":
         # Use local embedding model
         embeddings = HuggingFaceBgeEmbeddings(model_name=TEI_EMBED_MODEL)
     else:
-        if logflag:
-            logger.warning("No embeddings environment variables are set, cannot generate embeddings.")
-        embeddings = None
+        raise ValueError("No embeddings environment variables are set, cannot generate embeddings.")
 
     ############
     # ArangoDB #

--- a/comps/dataprep/arango/langchain/prepare_doc_arango.py
+++ b/comps/dataprep/arango/langchain/prepare_doc_arango.py
@@ -191,6 +191,9 @@ async def ingest_documents(
         logger.info(f"files:{files}")
         logger.info(f"link_list:{link_list}")
 
+    if not files and not link_list:
+        raise HTTPException(status_code=400, detail="Must provide either a file or a string list.")
+
     graph_names_created = set()
 
     if files:
@@ -201,18 +204,21 @@ async def ingest_documents(
             encode_file = encode_filename(file.filename)
             save_path = upload_folder + encode_file
             await save_content_to_local_disk(save_path, file)
-            graph_name = ingest_data_to_arango(
-                DocPath(
-                    path=save_path,
-                    chunk_size=chunk_size,
-                    chunk_overlap=chunk_overlap,
-                    process_table=process_table,
-                    table_strategy=table_strategy,
-                ),
-            )
+            try:
+                graph_name = ingest_data_to_arango(
+                    DocPath(
+                        path=save_path,
+                        chunk_size=chunk_size,
+                        chunk_overlap=chunk_overlap,
+                        process_table=process_table,
+                        table_strategy=table_strategy,
+                    ),
+                )
 
-            uploaded_files.append(save_path)
-            graph_names_created.add(graph_name)
+                uploaded_files.append(save_path)
+                graph_names_created.add(graph_name)
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=f"Failed to ingest {save_path} into ArangoDB: {e}")
 
             if logflag:
                 logger.info(f"Successfully saved file {save_path}")
@@ -225,8 +231,8 @@ async def ingest_documents(
             encoded_link = encode_filename(link)
             save_path = upload_folder + encoded_link + ".txt"
             content = parse_html([link])[0][0]
+            await save_content_to_local_disk(save_path, content)
             try:
-                await save_content_to_local_disk(save_path, content)
                 graph_name = ingest_data_to_arango(
                     DocPath(
                         path=save_path,
@@ -237,14 +243,11 @@ async def ingest_documents(
                     ),
                 )
                 graph_names_created.add(graph_name)
-            except json.JSONDecodeError:
-                raise HTTPException(status_code=500, detail="Fail to ingest data into qdrant.")
+            except Exception as e:
+                raise HTTPException(status_code=500, detail=f"Failed to ingest {save_path} into ArangoDB: {e}")
 
             if logflag:
                 logger.info(f"Successfully saved link {link}")
-
-    if len(graph_names_created) == 0:
-        raise HTTPException(status_code=400, detail="Must provide either a file or a string list.")
 
     graph_names_created = list(graph_names_created)
 

--- a/comps/dataprep/arango/langchain/prepare_doc_arango.py
+++ b/comps/dataprep/arango/langchain/prepare_doc_arango.py
@@ -130,7 +130,7 @@ def ingest_data_to_arango(doc_path: DocPath) -> str:
             chunks = chunks + table_chunks
 
     if logflag:
-        logger.info(f"Done preprocessing. Created {len(chunks)} chunks of the original file.")
+        logger.info(f"Created {len(chunks)} chunks of the original file.")
 
     ################################
     # Graph generation & insertion #
@@ -147,7 +147,10 @@ def ingest_data_to_arango(doc_path: DocPath) -> str:
         file_name = os.path.basename(path).split(".")[0]
         graph_name = "".join(c for c in file_name if c.isalnum() or c in "_-:.@()+,=;$!*'%")
 
-    for text in chunks:
+    if logflag:
+        logger.info(f"Creating graph {graph_name}.")
+
+    for i, text in enumerate(chunks):
         document = Document(page_content=text)
         graph_doc = llm_transformer.process_response(document)
 
@@ -164,6 +167,9 @@ def ingest_data_to_arango(doc_path: DocPath) -> str:
             insert_async=INSERT_ASYNC,
             source_metadata_fields_to_extract_to_top_level={"embedding"},
         )
+
+        if logflag:
+            logger.info(f"Chunk {i} processed into graph.")
 
     if logflag:
         logger.info("The graph is built.")

--- a/comps/dataprep/arango/langchain/prepare_doc_arango.py
+++ b/comps/dataprep/arango/langchain/prepare_doc_arango.py
@@ -12,6 +12,7 @@ from config import (
     ALLOWED_RELATIONSHIPS,
     ARANGO_BATCH_SIZE,
     ARANGO_DB_NAME,
+    ARANGO_GRAPH_NAME,
     ARANGO_PASSWORD,
     ARANGO_URL,
     ARANGO_USERNAME,
@@ -33,7 +34,6 @@ from config import (
     TGI_LLM_TIMEOUT,
     TGI_LLM_TOP_K,
     TGI_LLM_TOP_P,
-    USE_ONE_ENTITY_COLLECTION,
 )
 from fastapi import File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -86,7 +86,7 @@ if SYSTEM_PROMPT_PATH is not None:
         logger.error(f"Could not set custom Prompt: {e}")
 
 
-def ingest_data_to_arango(doc_path: DocPath, graph_name: str, generate_chunk_embeddings: bool) -> bool:
+def ingest_data_to_arango(doc_path: DocPath) -> str:
     """Ingest document to ArangoDB."""
     path = doc_path.path
 
@@ -140,6 +140,13 @@ def ingest_data_to_arango(doc_path: DocPath, graph_name: str, generate_chunk_emb
         generate_schema_on_init=False,
     )
 
+    graph_name = ARANGO_GRAPH_NAME
+    if not graph_name:
+        file_name = os.path.basename(path).split(".")[0]
+        graph_name = "".join(c for c in file_name if c.isalnum() or c in "_-:.@()+,=;$!*'%")
+
+    generate_chunk_embeddings = embeddings is not None
+
     for text in chunks:
         document = Document(page_content=text)
         graph_doc = llm_transformer.process_response(document)
@@ -152,9 +159,9 @@ def ingest_data_to_arango(doc_path: DocPath, graph_name: str, generate_chunk_emb
             graph_documents=[graph_doc],
             include_source=True,
             graph_name=graph_name,
-            update_graph_definition_if_exists=not USE_ONE_ENTITY_COLLECTION,
+            update_graph_definition_if_exists=False,
             batch_size=ARANGO_BATCH_SIZE,
-            use_one_entity_collection=USE_ONE_ENTITY_COLLECTION,
+            use_one_entity_collection=True,
             insert_async=INSERT_ASYNC,
             source_metadata_fields_to_extract_to_top_level={"embedding"},
         )
@@ -162,7 +169,7 @@ def ingest_data_to_arango(doc_path: DocPath, graph_name: str, generate_chunk_emb
     if logflag:
         logger.info("The graph is built.")
 
-    return True
+    return graph_name
 
 
 @register_microservice(
@@ -180,12 +187,12 @@ async def ingest_documents(
     chunk_overlap: int = Form(100),
     process_table: bool = Form(False),
     table_strategy: str = Form("fast"),
-    graph_name: str = Form("Graph"),
-    create_embeddings: bool = Form(True),
 ):
     if logflag:
         logger.info(f"files:{files}")
         logger.info(f"link_list:{link_list}")
+
+    graph_names_created = set()
 
     if files:
         if not isinstance(files, list):
@@ -195,7 +202,7 @@ async def ingest_documents(
             encode_file = encode_filename(file.filename)
             save_path = upload_folder + encode_file
             await save_content_to_local_disk(save_path, file)
-            ingest_data_to_arango(
+            graph_name = ingest_data_to_arango(
                 DocPath(
                     path=save_path,
                     chunk_size=chunk_size,
@@ -203,16 +210,13 @@ async def ingest_documents(
                     process_table=process_table,
                     table_strategy=table_strategy,
                 ),
-                graph_name=graph_name,
-                generate_chunk_embeddings=create_embeddings and embeddings is not None,
             )
+
             uploaded_files.append(save_path)
+            graph_names_created.add(graph_name)
+
             if logflag:
                 logger.info(f"Successfully saved file {save_path}")
-        result = {"status": 200, "message": "Data preparation succeeded"}
-        if logflag:
-            logger.info(result)
-        return result
 
     if link_list:
         link_list = json.loads(link_list)  # Parse JSON string to list
@@ -224,7 +228,7 @@ async def ingest_documents(
             content = parse_html([link])[0][0]
             try:
                 await save_content_to_local_disk(save_path, content)
-                ingest_data_to_arango(
+                graph_name = ingest_data_to_arango(
                     DocPath(
                         path=save_path,
                         chunk_size=chunk_size,
@@ -232,21 +236,29 @@ async def ingest_documents(
                         process_table=process_table,
                         table_strategy=table_strategy,
                     ),
-                    graph_name=graph_name,
-                    generate_chunk_embeddings=create_embeddings and embeddings is not None,
                 )
+                graph_names_created.add(graph_name)
             except json.JSONDecodeError:
                 raise HTTPException(status_code=500, detail="Fail to ingest data into qdrant.")
 
             if logflag:
                 logger.info(f"Successfully saved link {link}")
 
-        result = {"status": 200, "message": "Data preparation succeeded"}
-        if logflag:
-            logger.info(result)
-        return result
+    if len(graph_names_created) == 0:
+        raise HTTPException(status_code=400, detail="Must provide either a file or a string list.")
 
-    raise HTTPException(status_code=400, detail="Must provide either a file or a string list.")
+    graph_names_created = list(graph_names_created)
+
+    result = {
+        "status": 200,
+        "message": f"Data preparation succeeded: {graph_names_created}",
+        "graph_names": graph_names_created,
+    }
+
+    if logflag:
+        logger.info(result)
+
+    return result
 
 
 if __name__ == "__main__":

--- a/comps/dataprep/arango/langchain/prepare_doc_arango.py
+++ b/comps/dataprep/arango/langchain/prepare_doc_arango.py
@@ -36,6 +36,7 @@ from config import (
     TGI_LLM_TOP_P,
     OPENAI_CHAT_ENABLED,
     OPENAI_EMBED_ENABLED,
+    ARANGO_USE_GRAPH_NAME,
 )
 from fastapi import File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -142,8 +143,9 @@ def ingest_data_to_arango(doc_path: DocPath) -> str:
         generate_schema_on_init=False,
     )
 
-    graph_name = ARANGO_GRAPH_NAME
-    if not graph_name:
+    if ARANGO_USE_GRAPH_NAME:
+        graph_name = ARANGO_GRAPH_NAME
+    else:
         file_name = os.path.basename(path).split(".")[0]
         graph_name = "".join(c for c in file_name if c.isalnum() or c in "_-:.@()+,=;$!*'%")
 


### PR DESCRIPTION
- Replacing the API parameters that we introduced in the Dataprep service in favour of more environment variables
- This is (unfortunately) required for now, as we don't want to deal with modifying the ChatQnA UI to accept these parameters

What's changed:
- Removed `USE_ONE_ENTITY_COLLECTION` environment variable
- Added `ARANGO_GRAPH_NAME` environment variable
- Remove `graph_name` API parameter in `/v1/dataprep` endpoint
- Allow using the file name as the ArangoDB Graph Name
- Improving the result returned from `/v1/dataprep`