### PR TITLE
Added environment variables for dataprep parsing config

### DIFF
--- a/comps/dataprep/arango/langchain/config.py
+++ b/comps/dataprep/arango/langchain/config.py
@@ -43,3 +43,9 @@ ALLOWED_NODES = os.getenv("ALLOWED_NODES", [])
 ALLOWED_RELATIONSHIPS = os.getenv("ALLOWED_RELATIONSHIPS", [])
 NODE_PROPERTIES = os.getenv("NODE_PROPERTIES", ["description"])
 RELATIONSHIP_PROPERTIES = os.getenv("RELATIONSHIP_PROPERTIES", ["description"])
+
+# Parsing configuration
+PROCESS_TABLE = os.getenv("PROCESS_TABLE", "false").lower() == "true"
+TABLE_STRATEGY = os.getenv("TABLE_STRATEGY", "fast")
+CHUNK_SIZE = int(os.getenv("CHUNK_SIZE", 1500))
+CHUNK_OVERLAP = int(os.getenv("CHUNK_OVERLAP", 100))

--- a/comps/dataprep/arango/langchain/prepare_doc_arango.py
+++ b/comps/dataprep/arango/langchain/prepare_doc_arango.py
@@ -37,6 +37,10 @@ from config import (
     OPENAI_CHAT_ENABLED,
     OPENAI_EMBED_ENABLED,
     ARANGO_USE_GRAPH_NAME,
+    PROCESS_TABLE,
+    TABLE_STRATEGY,
+    CHUNK_SIZE,
+    CHUNK_OVERLAP,
 )
 from fastapi import File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -190,10 +194,10 @@ def ingest_data_to_arango(doc_path: DocPath) -> str:
 async def ingest_documents(
     files: Optional[Union[UploadFile, List[UploadFile]]] = File(None),
     link_list: Optional[str] = Form(None),
-    chunk_size: int = Form(1500),
-    chunk_overlap: int = Form(100),
-    process_table: bool = Form(False),
-    table_strategy: str = Form("fast"),
+    chunk_size: int = Form(CHUNK_SIZE),
+    chunk_overlap: int = Form(CHUNK_OVERLAP), 
+    process_table: bool = Form(PROCESS_TABLE),
+    table_strategy: str = Form(TABLE_STRATEGY),
 ):
     if logflag:
         logger.info(f"files:{files}")


### PR DESCRIPTION
Minor change, all defaults from curl commands have been replaced with environment variables that can be set. These include Chunk Size, Chunk Overlap, Process Table, Table Strategy.
